### PR TITLE
Sleep for longer so that instances have a longer time to start up

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -8,7 +8,7 @@ chmod +x kasm_dependencies.sh
 chmod +x kasm_aws_instances.sh
 ./kasm_aws_instances.sh
 
-sleep 20
+sleep 300
 
 # Run the command execution script
 chmod +x kasm_servers_tools.sh


### PR DESCRIPTION
This needs to be changed in the future, working on pinging server so that after AWS initializes the resource, we can access it.